### PR TITLE
Add FPS limit option + fix Minecraft getting unfocused

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # Plugin properties
 maven_group=xyz.duncanruns.jingle.eyesee
-plugin_version=0.1.2
+plugin_version=0.1.3
 archives_base_name=jingle-eyesee-plugin

--- a/src/main/java/xyz/duncanruns/jingle/eyesee/EyeSee.java
+++ b/src/main/java/xyz/duncanruns/jingle/eyesee/EyeSee.java
@@ -25,6 +25,10 @@ public class EyeSee {
         return options;
     }
 
+    public static EyeSeeFrame getEyeSeeFrame() {
+        return eyeSeeFrame;
+    }
+
     public static void main(String[] args) throws IOException {
         JingleAppLaunch.launchWithDevPlugin(args, PluginManager.JinglePluginData.fromString(
                 Resources.toString(Resources.getResource(EyeSee.class, "/jingle.plugin.json"), Charset.defaultCharset())
@@ -32,7 +36,6 @@ public class EyeSee {
     }
 
     public static void initialize() {
-        eyeSeeFrame = new EyeSeeFrame();
         Optional<EyeSeeOptions> loadedOptions = EyeSeeOptions.load();
         if (loadedOptions.isPresent()) {
             options = loadedOptions.get();
@@ -40,6 +43,8 @@ public class EyeSee {
             options = new EyeSeeOptions();
             Jingle.log(Level.ERROR, "Failed to load EyeSeeOptions, using defaults.");
         }
+
+        eyeSeeFrame = new EyeSeeFrame();
 
         JingleGUI.addPluginTab("EyeSee", new EyeSeePluginPanel().mainPanel);
 

--- a/src/main/java/xyz/duncanruns/jingle/eyesee/EyeSeeOptions.java
+++ b/src/main/java/xyz/duncanruns/jingle/eyesee/EyeSeeOptions.java
@@ -19,6 +19,7 @@ public class EyeSeeOptions {
     public int y;
     public int w;
     public int h;
+    public int fpsLimit = 30;
 
     public static Optional<EyeSeeOptions> load() {
         if (!Files.exists(OPTIONS_PATH)) return Optional.of(new EyeSeeOptions());

--- a/src/main/java/xyz/duncanruns/jingle/eyesee/frames/EyeSeeFrame.java
+++ b/src/main/java/xyz/duncanruns/jingle/eyesee/frames/EyeSeeFrame.java
@@ -86,7 +86,9 @@ public class EyeSeeFrame extends JFrame {
         Jingle.log(Level.DEBUG, "Showing EyeSee...");
 
         currentlyShowing = true;
+        this.setFocusableWindowState(false);
         this.setVisible(true);
+        this.overlay.setFocusableWindowState(false);
         this.overlay.setVisible(true);
         bounds = rect;
 

--- a/src/main/java/xyz/duncanruns/jingle/eyesee/frames/EyeSeeFrame.java
+++ b/src/main/java/xyz/duncanruns/jingle/eyesee/frames/EyeSeeFrame.java
@@ -5,6 +5,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinDef;
 import org.apache.logging.log4j.Level;
 import xyz.duncanruns.jingle.Jingle;
+import xyz.duncanruns.jingle.eyesee.EyeSee;
 import xyz.duncanruns.jingle.eyesee.win32.GDI32Extra;
 import xyz.duncanruns.jingle.util.WindowStateUtil;
 import xyz.duncanruns.jingle.win32.User32;
@@ -17,6 +18,7 @@ import java.awt.geom.AffineTransform;
 import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -27,6 +29,7 @@ public class EyeSeeFrame extends JFrame {
     private static final WinDef.DWORD SRCCOPY = new WinDef.DWORD(0x00CC0020);
     private final OverlayFrame overlay = new OverlayFrame();
     ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledFuture<?> redrawTask;
 
     private final WinDef.HWND eyeSeeHwnd;
     private boolean currentlyShowing = false;
@@ -55,9 +58,7 @@ public class EyeSeeFrame extends JFrame {
         WindowStateUtil.setHwndBorderless(eyeSeeHwnd);
 
         tick();
-        // 30 = refresh rate
-        // TODO: adjustable?
-        this.executor.scheduleAtFixedRate(this::tick, 50_000_000, 1_000_000_000L / 30, TimeUnit.NANOSECONDS);
+        restartDrawingTask(EyeSee.getOptions().fpsLimit);
         this.setVisible(false);
 
 //        this.showEyeSee();
@@ -153,6 +154,18 @@ public class EyeSeeFrame extends JFrame {
 
 //        this.overlay.setSize(1, 1);
 //        this.overlay.setLocation(0, -monitor.height);
+    }
+
+    /**
+     * Stops an ongoing drawing task and starts a new one with the specified FPS limit.
+     */
+    public void restartDrawingTask(int fpsLimit) {
+        if (redrawTask != null) {
+            redrawTask.cancel(false);
+        }
+
+        long delay = 1_000_000_000L / fpsLimit;
+        redrawTask = this.executor.scheduleAtFixedRate(this::tick, delay, delay, TimeUnit.NANOSECONDS);
     }
 
     @Override

--- a/src/main/java/xyz/duncanruns/jingle/eyesee/gui/EyeSeePluginPanel.form
+++ b/src/main/java/xyz/duncanruns/jingle/eyesee/gui/EyeSeePluginPanel.form
@@ -24,7 +24,7 @@
           <text value="Automatically Position EyeSee Measuring Projector"/>
         </properties>
       </component>
-      <grid id="fad62" binding="customizationPanel" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="fad62" binding="customizationPanel" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="2" indent="0" use-parent-layout="false"/>
@@ -90,10 +90,28 @@
           </component>
           <component id="1c220" class="javax.swing.JButton" binding="applyButton" default-binding="true">
             <constraints>
-              <grid row="0" column="3" row-span="2" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="3" row-span="3" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Apply"/>
+            </properties>
+          </component>
+          <component id="b7b94" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="FPS Limit:"/>
+            </properties>
+          </component>
+          <component id="8b9b7" class="javax.swing.JTextField" binding="projFpsLimitField">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="60" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
             </properties>
           </component>
         </children>

--- a/src/main/java/xyz/duncanruns/jingle/eyesee/gui/EyeSeePluginPanel.java
+++ b/src/main/java/xyz/duncanruns/jingle/eyesee/gui/EyeSeePluginPanel.java
@@ -34,15 +34,15 @@ public class EyeSeePluginPanel {
             Rectangle projectorRect = EyeSee.getProjectorRect();
             options.autoPos = autoBox.isSelected();
             if (options.autoPos) {
-                projPosXField.setText("");
-                projPosYField.setText("");
-                projPosWField.setText("");
-                projPosHField.setText("");
+                projPosXField.setText(null);
+                projPosYField.setText(null);
+                projPosWField.setText(null);
+                projPosHField.setText(null);
             } else {
-                projPosXField.setText("" + projectorRect.x);
-                projPosYField.setText("" + projectorRect.y);
-                projPosWField.setText("" + projectorRect.width);
-                projPosHField.setText("" + projectorRect.height);
+                projPosXField.setText(String.valueOf(projectorRect.x));
+                projPosYField.setText(String.valueOf(projectorRect.y));
+                projPosWField.setText(String.valueOf(projectorRect.width));
+                projPosHField.setText(String.valueOf(projectorRect.height));
                 options.x = projectorRect.x;
                 options.y = projectorRect.y;
                 options.w = projectorRect.width;
@@ -54,25 +54,29 @@ public class EyeSeePluginPanel {
 
         if (!options.autoPos) {
             Rectangle projectorRect = EyeSee.getProjectorRect();
-            projPosXField.setText("" + projectorRect.x);
-            projPosYField.setText("" + projectorRect.y);
-            projPosWField.setText("" + projectorRect.width);
-            projPosHField.setText("" + projectorRect.height);
+            projPosXField.setText(String.valueOf(projectorRect.x));
+            projPosYField.setText(String.valueOf(projectorRect.y));
+            projPosWField.setText(String.valueOf(projectorRect.width));
+            projPosHField.setText(String.valueOf(projectorRect.height));
         }
 
         applyButton.addActionListener(a -> {
             int x = getIntFromField(projPosXField);
             options.x = x;
-            projPosXField.setText("" + x);
+            projPosXField.setText(String.valueOf(x));
+
             int y = getIntFromField(projPosYField);
             options.y = y;
-            projPosYField.setText("" + y);
+            projPosYField.setText(String.valueOf(y));
+
             int w = getIntFromField(projPosWField);
             options.w = w;
-            projPosWField.setText("" + w);
+            projPosWField.setText(String.valueOf(w));
+
             int h = getIntFromField(projPosHField);
             options.h = h;
             projPosHField.setText("" + h);
+            projPosHField.setText(String.valueOf(h));
         });
 
         reloadEnabledComponents();

--- a/src/main/java/xyz/duncanruns/jingle/eyesee/gui/EyeSeePluginPanel.java
+++ b/src/main/java/xyz/duncanruns/jingle/eyesee/gui/EyeSeePluginPanel.java
@@ -22,6 +22,7 @@ public class EyeSeePluginPanel {
     private JTextField projPosHField;
     private JButton applyButton;
     private JPanel customizationPanel;
+    private JTextField projFpsLimitField;
 
     public EyeSeePluginPanel() {
         EyeSeeOptions options = EyeSee.getOptions();
@@ -60,6 +61,8 @@ public class EyeSeePluginPanel {
             projPosHField.setText(String.valueOf(projectorRect.height));
         }
 
+        projFpsLimitField.setText(String.valueOf(options.fpsLimit));
+
         applyButton.addActionListener(a -> {
             int x = getIntFromField(projPosXField);
             options.x = x;
@@ -75,8 +78,14 @@ public class EyeSeePluginPanel {
 
             int h = getIntFromField(projPosHField);
             options.h = h;
-            projPosHField.setText("" + h);
             projPosHField.setText(String.valueOf(h));
+
+            int fps = clamp(getIntFromField(projFpsLimitField), 5, 240); // prevent small/huge fps values
+            options.fpsLimit = fps;
+            projFpsLimitField.setText(String.valueOf(fps));
+
+            // Restart the drawing task with updated FPS limit.
+            EyeSee.getEyeSeeFrame().restartDrawingTask(fps);
         });
 
         reloadEnabledComponents();
@@ -99,6 +108,10 @@ public class EyeSeePluginPanel {
             component.setEnabled(options.enabled && !options.autoPos);
         }
         autoBox.setEnabled(options.enabled);
+    }
+
+    private static int clamp(int i, int min, int max) {
+        return Math.max(min, Math.min(max, i));
     }
 
     {
@@ -126,7 +139,7 @@ public class EyeSeePluginPanel {
         autoBox.setText("Automatically Position EyeSee Measuring Projector");
         mainPanel.add(autoBox, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         customizationPanel = new JPanel();
-        customizationPanel.setLayout(new GridLayoutManager(2, 4, new Insets(0, 0, 0, 0), -1, -1));
+        customizationPanel.setLayout(new GridLayoutManager(3, 4, new Insets(0, 0, 0, 0), -1, -1));
         mainPanel.add(customizationPanel, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_VERTICAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         customizationPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEmptyBorder(), null, TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, null, null));
         final JLabel label1 = new JLabel();
@@ -149,12 +162,18 @@ public class EyeSeePluginPanel {
         customizationPanel.add(projPosHField, new GridConstraints(1, 2, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(30, -1), null, 0, false));
         applyButton = new JButton();
         applyButton.setText("Apply");
-        customizationPanel.add(applyButton, new GridConstraints(0, 3, 2, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        customizationPanel.add(applyButton, new GridConstraints(0, 3, 3, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final JLabel label3 = new JLabel();
+        label3.setText("FPS Limit:");
+        customizationPanel.add(label3, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        projFpsLimitField = new JTextField();
+        projFpsLimitField.setText("");
+        customizationPanel.add(projFpsLimitField, new GridConstraints(2, 1, 1, 2, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(60, -1), null, 0, false));
         final Spacer spacer1 = new Spacer();
         mainPanel.add(spacer1, new GridConstraints(5, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
-        final JLabel label3 = new JLabel();
-        label3.setText("<html> <h2>Warning</h2> The EyeSee plugin provides a measuring projector that works without the use of OBS.<br> It's possible this projector will fail to work for any of the following reasons: <ul> <li>Usage of an AMD GPU</li> <li>Being on a Laptop</li> <li>Certain hardware configurations</li> <li>Not being blessed by the Jingle God</li> </ul> If you can't get the EyeSee projector to work, try using an OBS projector (check out the OBS tab). </html>");
-        mainPanel.add(label3, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final JLabel label4 = new JLabel();
+        label4.setText("<html> <h2>Warning</h2> The EyeSee plugin provides a measuring projector that works without the use of OBS.<br> It's possible this projector will fail to work for any of the following reasons: <ul> <li>Usage of an AMD GPU</li> <li>Being on a Laptop</li> <li>Certain hardware configurations</li> <li>Not being blessed by the Jingle God</li> </ul> If you can't get the EyeSee projector to work, try using an OBS projector (check out the OBS tab). </html>");
+        mainPanel.add(label4, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JSeparator separator1 = new JSeparator();
         mainPanel.add(separator1, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
     }


### PR DESCRIPTION
Basically the title, I added an FPS limit option (default of 30, min of 5 and max of 240, arbitrarily chosen).
Also a 2 line fix for Minecraft getting unfocused rarely (Swing's `setVisible(true)` was focusing the JFrame by default)

![image](https://github.com/user-attachments/assets/c653fbd0-1f9e-4a24-9432-746a1cff8ec1)
